### PR TITLE
fix/tp2022 t16 119 document navigation sections

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,6 @@
 import { Viewer } from './lib/components/Viewer'
 //import { pdf_data } from './examples_PDF/samplePDF'
-import { pdf_data } from './examples_PDF/outlinedSamplePDF'
+import { pdf_data } from './examples_PDF/latexSamplePDF'
 
 /**
  *

--- a/src/lib/components/document/Document.tsx
+++ b/src/lib/components/document/Document.tsx
@@ -71,6 +71,10 @@ const Document = ({ data }: IDocumentProps) => {
           return
         }
 
+        if (typeof outline[0].dest === 'string') {
+          return
+        }
+
         const toc = await getTableOfContents(outline, 0, doc)
         setOutline(toc)
       })


### PR DESCRIPTION
quick fix:
- latex sample PDF will be displayed (because of potential dev version presentation)
- on latex sample PDF outlines object has a different structure and it needs to be reworked (in the code implementation)
- quick fix to detect string in outline dest field. We are not generating TOC in this case so in the console there won't be error.